### PR TITLE
Place css anywhere. Closes #4

### DIFF
--- a/src/StyleInliner.php
+++ b/src/StyleInliner.php
@@ -12,6 +12,9 @@ use enovatedesign\styleinliner\twigextensions\StyleInlinerTwigExtension;
 
 use Craft;
 use craft\base\Plugin;
+use craft\web\twig\variables\CraftVariable;
+
+use yii\base\Event;
 
 /**
  * Class StyleInliner
@@ -45,6 +48,15 @@ class StyleInliner extends Plugin
         self::$plugin = $this;
 
         Craft::$app->getView()->registerTwigExtension(new StyleInlinerTwigExtension());
+
+        Event::on(CraftVariable::class, CraftVariable::EVENT_INIT, function (Event $e) {
+            /** @var CraftVariable $variable */
+            $variable = $e->sender;
+
+            // Attach a service:
+            $variable->set('styleinliner', StyleInlinerTwigExtension::class);
+        });
+
     }
 
     protected function createSettingsModel()

--- a/src/services/StyleInlinerService.php
+++ b/src/services/StyleInlinerService.php
@@ -34,6 +34,7 @@ class StyleInlinerService extends Component
      * @var array
      */
     private $_criticalFilenames = [];
+
     /**
      * @inheritdoc
      */
@@ -59,9 +60,9 @@ class StyleInlinerService extends Component
      * Inlines an entire CSS file into the <head> of the document.
      *
      * @param $filename
+     * @return null
      * @throws \yii\base\ExitException
      *
-     * @return null
      */
     public function criticalCss($filename)
     {
@@ -70,13 +71,42 @@ class StyleInlinerService extends Component
         }
 
         $settings = StyleInliner::$plugin->getSettings();
-
         $fullPath = Craft::getAlias($settings->criticalPrefix . $filename . '.css');
-
-        if (file_exists($fullPath) && $content = @file_get_contents($fullPath)) {
+        if (file_exists($fullPath) && $content .= @file_get_contents($fullPath)) {
             $this->_criticalFilenames[] = $filename;
-
             Craft::$app->getView()->registerCss($content, [], 'critical');
         }
     }
+
+    /**
+     * Inlines an entire CSS file wherever you specify it
+     *
+     * e.g: {{  craft.styleinliner.printcriticalcss('fullwidth') | raw }}
+     *
+     * @param $filename
+     * @return string
+     * @throws \yii\base\ExitException
+     *
+     */
+    public function printCriticalCss($filename)
+    {
+        if (in_array($filename, $this->_criticalFilenames)) {
+            return;
+        }
+
+        $settings = StyleInliner::$plugin->getSettings();
+        $fullPath = Craft::getAlias($settings->criticalPrefix . $filename . '.css');
+        $content = '<style>';
+        $contents = @file_get_contents($fullPath);
+
+        if (file_exists($fullPath) && $contents) {
+            $content .= $contents;
+            $this->_criticalFilenames[] = $filename;
+            $content .= '</style>';
+            return $content;
+        }
+
+        return '';
+    }
+
 }

--- a/src/twigextensions/CriticalCssNode.php
+++ b/src/twigextensions/CriticalCssNode.php
@@ -21,16 +21,18 @@ class CriticalCssNode extends \Twig_Node
 {
     public function compile(\Twig_Compiler $compiler)
     {
+
         if (!StyleInliner::$plugin->getSettings()->criticalCss) {
             return;
         }
+
 
         $value = $this->getNode('value');
 
         $compiler->addDebugInfo($this);
 
         $compiler
-            ->write(StyleInliner::class."::\$plugin->styleInliner->criticalCss(")
+            ->write(StyleInliner::class . "::\$plugin->styleInliner->criticalCss(")
             ->subcompile($value)
             ->write(");");
     }

--- a/src/twigextensions/StyleInlinerTwigExtension.php
+++ b/src/twigextensions/StyleInlinerTwigExtension.php
@@ -7,6 +7,7 @@
 
 namespace enovatedesign\styleinliner\twigextensions;
 
+use enovatedesign\styleinliner\StyleInliner;
 use Twig_Extension;
 use Twig_TokenParserInterface;
 
@@ -31,4 +32,10 @@ class StyleInlinerTwigExtension extends Twig_Extension
             new CriticalCssTokenParser(),
         ];
     }
+
+    public function printcriticalcss($key)
+    {
+        return StyleInliner::$plugin->styleInliner->printCriticalCss($key);
+    }
+
 }


### PR DESCRIPTION
You can now place your critical css wherever you may need it.

Usage:
`{{  craft.styleinliner.printcriticalcss('fullwidth') | raw }}`

