### PR TITLE
Remove direct enshrined/svg-sanitize dep

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
   "license": "MIT",
   "require": {
     "tijsverkoyen/css-to-inline-styles": "^2.2.7",
-    "enshrined/svg-sanitize": "^0.16.0",
     "craftcms/cms": "^5.2",
     "php": "^8.2.0",
     "guzzlehttp/guzzle": "^7.2.0"


### PR DESCRIPTION
`craftcms/cms` already requires `enshrined/svg-sanitize`, so requiring it can be problematic.
Eg, this plugin can be come un-installable if Craft updates its version, [as is happing in 5.3](https://github.com/craftcms/cms/commit/6907c175107c390e821a6a4c7672876b0690dedf).